### PR TITLE
0.3.1 - Add prop to put chart title only on saveAsImage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazing-react-charts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An amazing react charts package based in echarts",
   "author": "Leonardo Filipe Rigon",
   "license": "MIT",

--- a/src/core/AreaChart.tsx
+++ b/src/core/AreaChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import ReactEcharts from 'echarts-for-react'
 import {
   fixedDomain,
@@ -11,7 +11,7 @@ import {
   getSaveAsImage,
   timeConvert,
   toDate,
-  takeLabelComplement
+  takeLabelComplement,
 } from './auxiliarFunctions'
 import {
   IDefaultChartProps,
@@ -22,6 +22,17 @@ import {
 } from './types'
 
 export const STYLES = { width: '99.9%', height: 300 }
+export const TOOLBOX_DEFAULT_PROPS = {
+  showTitle: false,
+  right: '9.52%',
+  tooltip: {
+    show: true,
+    backgroundColor: 'grey',
+    textStyle: {
+      fontSize: 12
+    }
+  }
+}
 
 const AreaChart = (props: IDefaultChartProps) => {
   const {
@@ -106,20 +117,12 @@ const AreaChart = (props: IDefaultChartProps) => {
   }
 
   const toolbox = toolboxTooltip && {
-    showTitle: false,
-    right: '9.52%',
+    ...TOOLBOX_DEFAULT_PROPS,
     feature: {
-      saveAsImage:
-        toolboxTooltip.saveAsImage &&
-        getSaveAsImage(toolboxTooltip.saveAsImage),
+      saveAsImage: toolboxTooltip && toolboxTooltip.saveAsImage && {
+        saveAsImage: getSaveAsImage(toolboxTooltip.saveAsImage)
+      },
       dataView: toolboxTooltip.dataView && getDataView(toolboxTooltip.dataView)
-    },
-    tooltip: {
-      show: true,
-      backgroundColor: 'grey',
-      textStyle: {
-        fontSize: 12
-      }
     }
   }
 
@@ -202,7 +205,6 @@ const AreaChart = (props: IDefaultChartProps) => {
             ? formatTime(item, dateFormat === 'yyyy-MM' ? 'MMM/yy' : 'dd MMM')
             : item,
         rotate: rotateLabel || 0,
-        interval: 0,
         rich: {
           textStyle: {
             fontSize: fontLabelSize || 11.5

--- a/src/core/AreaChart.tsx
+++ b/src/core/AreaChart.tsx
@@ -11,7 +11,7 @@ import {
   getSaveAsImage,
   timeConvert,
   toDate,
-  takeLabelComplement,
+  takeLabelComplement
 } from './auxiliarFunctions'
 import {
   IDefaultChartProps,

--- a/src/core/AudiometryChart.tsx
+++ b/src/core/AudiometryChart.tsx
@@ -9,7 +9,12 @@ import {
   TOptionsProps
 } from './types'
 import { map, zipWith } from 'ramda'
-import { getDataView, getSaveAsImageWithTitle } from './auxiliarFunctions'
+import {
+  getDataView, 
+  getSaveAsImageWithTitle, 
+  getSaveAsImage
+} from './auxiliarFunctions'
+import { TOOLBOX_DEFAULT_PROPS } from './AreaChart'
 
 const xFixedData: string[] = ['.25', '.5', '1', '2', '3', '4', '6', '8']
 
@@ -85,27 +90,24 @@ const AudiometryChart = (props: IProps) => {
     data
   )
 
-  const myTool = toolboxTooltip && toolboxTooltip.saveAsImageWithTitle &&
-    getSaveAsImageWithTitle(
+  const myTool = toolboxTooltip && toolboxTooltip.saveAsImageWithTitle && {
+    myTool: getSaveAsImageWithTitle(
       toolboxTooltip.saveAsImageWithTitle,
       handleShowTitle
     )
+  }
+
+  const saveAsImage = toolboxTooltip && toolboxTooltip.saveAsImage && {
+    saveAsImage: getSaveAsImage(toolboxTooltip.saveAsImage)
+  }
 
   const toolbox = toolboxTooltip && {
-    showTitle: false,
-    right: '9.52%',
+    ...TOOLBOX_DEFAULT_PROPS,
     feature: {
-      myTool: myTool,
-      dataView:
-        toolboxTooltip.dataView &&
+      ...myTool,
+      ...saveAsImage,
+      dataView: toolboxTooltip.dataView &&
         getDataView(toolboxTooltip.dataView)
-    },
-    tooltip: {
-      show: true,
-      backgroundColor: 'grey',
-      textStyle: {
-        fontSize: 12
-      }
     }
   }
 

--- a/src/core/AudiometryChart.tsx
+++ b/src/core/AudiometryChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import ReactEcharts from 'echarts-for-react'
 import {
   IDefaultChartProps,
@@ -9,11 +9,7 @@ import {
   TOptionsProps
 } from './types'
 import { map, zipWith } from 'ramda'
-import {
-  getDataView,
-  getSaveAsImage,
-  getSaveAsImageWithTitle
-} from './auxiliarFunctions'
+import { getDataView, getSaveAsImageWithTitle } from './auxiliarFunctions'
 
 const xFixedData: string[] = ['.25', '.5', '1', '2', '3', '4', '6', '8']
 
@@ -39,7 +35,27 @@ const formatTooltip = (items: TAudiometryDataTooltip[]) => {
 }
 
 const AudiometryChart = (props: IProps) => {
+  const {
+    title: titleProps,
+    symbolsSize,
+    data,
+    toolboxTooltip,
+    lineType,
+    color,
+    grid,
+    height,
+    width
+  } = props
+
   const [title, setTitle] = useState(false)
+
+  useEffect(() => {
+    if (toolboxTooltip && toolboxTooltip.saveAsImageWithTitle) {
+      setTitle(false)
+    } else {
+      setTitle(true)
+    }
+  }, [toolboxTooltip])
 
   const handleShowTitle = (show: boolean) => {
     setTitle(show)
@@ -49,11 +65,11 @@ const AudiometryChart = (props: IProps) => {
     item => ({
       value: item.result,
       symbol: item.symbol,
-      symbolSize: props.symbolsSize || 12,
+      symbolSize: symbolsSize || 12,
       name: item.result,
       boneValue: item.boneResult
     }),
-    props.data
+    data
   )
 
   const marks: TCostumizedSymbolData[] = zipWith(
@@ -62,29 +78,27 @@ const AudiometryChart = (props: IProps) => {
         ? {
           value: data.boneResult,
           symbol: data.boneSymbol,
-          symbolSize: props.symbolsSize || 12
+          symbolSize: symbolsSize || 12
         }
         : {},
     xFixedData,
-    props.data
+    data
   )
 
-  const toolbox = props.toolboxTooltip && {
+  const myTool = toolboxTooltip && toolboxTooltip.saveAsImageWithTitle &&
+    getSaveAsImageWithTitle(
+      toolboxTooltip.saveAsImageWithTitle,
+      handleShowTitle
+    )
+
+  const toolbox = toolboxTooltip && {
     showTitle: false,
     right: '9.52%',
     feature: {
-      saveAsImage:
-        props.toolboxTooltip.saveAsImage && !props.showTitleOnlySave &&
-        getSaveAsImage(props.toolboxTooltip.saveAsImage),
-      myTool:
-        props.toolboxTooltip.saveAsImage && props.showTitleOnlySave &&
-        getSaveAsImageWithTitle(
-          props.toolboxTooltip.saveAsImage,
-          handleShowTitle
-        ),
+      myTool: myTool,
       dataView:
-        props.toolboxTooltip.dataView &&
-        getDataView(props.toolboxTooltip.dataView)
+        toolboxTooltip.dataView &&
+        getDataView(toolboxTooltip.dataView)
     },
     tooltip: {
       show: true,
@@ -94,7 +108,6 @@ const AudiometryChart = (props: IProps) => {
       }
     }
   }
-
 
   const tooltip = {
     formatter: formatTooltip,
@@ -109,7 +122,7 @@ const AudiometryChart = (props: IProps) => {
         type: 'line',
         lineStyle: {
           width: 1,
-          type: props.lineType || 'solid'
+          type: lineType || 'solid'
         },
         data: yData
       },
@@ -130,13 +143,13 @@ const AudiometryChart = (props: IProps) => {
         lineStyle: {
           type: 'solid',
           opacity: 0.2,
-          color: props.color || 'red'
+          color: color || 'red'
         },
       },
       axisLine: {
         onZeroAxisIndex: 1,
         lineStyle: {
-          color: props.color || 'red'
+          color: color || 'red'
         }
       },
       axisTick: {
@@ -155,7 +168,7 @@ const AudiometryChart = (props: IProps) => {
         lineStyle: {
           type: 'solid',
           opacity: 0.2,
-          color: props.color || 'red'
+          color: color || 'red'
         },
       },
       axisTick: {
@@ -164,33 +177,33 @@ const AudiometryChart = (props: IProps) => {
       axisLine: {
         onZero: true,
         lineStyle: {
-          color: props.color || 'red'
+          color: color || 'red'
         }
       }
     },
-    toolbox,
     title: {
       left: '6.2%',
-      show: title && props.title !== undefined,
-      text: props.title,
+      show: title,
+      text: titleProps,
       textAlign: 'left',
       textStyle: {
         fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
         fontSize: 16,
         fontWeight: '400' as const,
-        color: props.color || 'red'
+        color: color || 'red'
       }
     },
-    tooltip,
-    color: [props.color || 'red'],
+    color: [color || 'red'],
     grid: {
-      ...props.grid,
+      ...grid,
       show: false
-    }
+    },
+    toolbox,
+    tooltip
   }
 
-  const style = { width: '99.9%', height: props.height || 400 }
-  const widthOpts = { width: props.width || 'auto' }
+  const style = { width: '99.9%', height: height || 400 }
+  const widthOpts = { width: width || 'auto' }
 
   return (
     <ReactEcharts

--- a/src/core/AudiometryChart.tsx
+++ b/src/core/AudiometryChart.tsx
@@ -10,8 +10,8 @@ import {
 } from './types'
 import { map, zipWith } from 'ramda'
 import {
-  getDataView, 
-  getSaveAsImageWithTitle, 
+  getDataView,
+  getSaveAsImageWithTitle,
   getSaveAsImage
 } from './auxiliarFunctions'
 import { TOOLBOX_DEFAULT_PROPS } from './AreaChart'
@@ -26,17 +26,17 @@ interface IProps extends Omit<IDefaultChartProps, 'data'> {
 }
 
 const formatTooltip = (items: TAudiometryDataTooltip[]) => {
-  const result =
-    items[0].data.value || items[0].data.value === 0
-      ? `Limiar Aéreo: ${items[0].data.value} dB <br>`
-      : ''
+  const item = items.length > 0 ? items[0].data : { value: 0, boneValue: 0 }
 
-  const boneResult =
-    items[0].data.boneValue || items[0].data.boneValue === 0
-      ? `Limiar Ósseo: ${items[0].data.boneValue} dB`
-      : ''
+  const result = item.value || item.value === 0
+    ? `Limiar Aéreo: ${item.value} dB <br>`
+    : ''
 
-  return items[0] && items[0].data ? result + boneResult : null
+  const boneResult = item.boneValue || item.boneValue === 0
+    ? `Limiar Ósseo: ${item.boneValue} dB`
+    : ''
+
+  return result + boneResult
 }
 
 const AudiometryChart = (props: IProps) => {

--- a/src/core/AudiometryChart.tsx
+++ b/src/core/AudiometryChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState } from 'react'
 import ReactEcharts from 'echarts-for-react'
 import {
   IDefaultChartProps,
@@ -9,7 +9,11 @@ import {
   TOptionsProps
 } from './types'
 import { map, zipWith } from 'ramda'
-import { getDataView, getSaveAsImage } from './auxiliarFunctions'
+import {
+  getDataView,
+  getSaveAsImage,
+  getSaveAsImageWithTitle
+} from './auxiliarFunctions'
 
 const xFixedData: string[] = ['.25', '.5', '1', '2', '3', '4', '6', '8']
 
@@ -35,6 +39,12 @@ const formatTooltip = (items: TAudiometryDataTooltip[]) => {
 }
 
 const AudiometryChart = (props: IProps) => {
+  const [title, setTitle] = useState(false)
+
+  const handleShowTitle = (show: boolean) => {
+    setTitle(show)
+  }
+
   const yData = map(
     item => ({
       value: item.result,
@@ -59,27 +69,19 @@ const AudiometryChart = (props: IProps) => {
     props.data
   )
 
-  const title = {
-    id: 'chart-' + props.title,
-    left: '6.2%',
-    show: props.title !== undefined,
-    text: props.title,
-    textAlign: 'left',
-    textStyle: {
-      fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
-      fontSize: 16,
-      fontWeight: '400' as const,
-      color: props.color || 'red'
-    }
-  }
-
   const toolbox = props.toolboxTooltip && {
     showTitle: false,
     right: '9.52%',
     feature: {
       saveAsImage:
-        props.toolboxTooltip.saveAsImage &&
+        props.toolboxTooltip.saveAsImage && !props.showTitleOnlySave &&
         getSaveAsImage(props.toolboxTooltip.saveAsImage),
+      myTool:
+        props.toolboxTooltip.saveAsImage && props.showTitleOnlySave &&
+        getSaveAsImageWithTitle(
+          props.toolboxTooltip.saveAsImage,
+          handleShowTitle
+        ),
       dataView:
         props.toolboxTooltip.dataView &&
         getDataView(props.toolboxTooltip.dataView)
@@ -92,6 +94,7 @@ const AudiometryChart = (props: IProps) => {
       }
     }
   }
+
 
   const tooltip = {
     formatter: formatTooltip,
@@ -166,7 +169,18 @@ const AudiometryChart = (props: IProps) => {
       }
     },
     toolbox,
-    title,
+    title: {
+      left: '6.2%',
+      show: title && props.title !== undefined,
+      text: props.title,
+      textAlign: 'left',
+      textStyle: {
+        fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
+        fontSize: 16,
+        fontWeight: '400' as const,
+        color: props.color || 'red'
+      }
+    },
     tooltip,
     color: [props.color || 'red'],
     grid: {
@@ -180,8 +194,6 @@ const AudiometryChart = (props: IProps) => {
 
   return (
     <ReactEcharts
-      lazyUpdate
-      notMerge
       style={style}
       opts={widthOpts}
       option={options}

--- a/src/core/CoordinateLineChart.tsx
+++ b/src/core/CoordinateLineChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState, useEffect } from 'react'
 import ReactEcharts from 'echarts-for-react'
 import {
   IDefaultChartProps,
@@ -7,6 +7,11 @@ import {
   TTuple
 } from './types'
 import { map } from 'ramda'
+import {
+  getSaveAsImageWithTitle,
+  getSaveAsImage, getDataView
+} from './auxiliarFunctions'
+import { TOOLBOX_DEFAULT_PROPS } from './AreaChart'
 
 export interface IProps extends Omit<IDefaultChartProps, 'data'> {
   coordinates: [TCoordinates[], TCoordinates[], TCoordinates[]]
@@ -36,10 +41,45 @@ const CoordinateLineChart = (props: IProps) => {
     xMaxValue,
     grid,
     legendPosition,
-    width
+    width,
+    toolboxTooltip
   } = props
 
+  const [title, setTitle] = useState(false)
   const [ref, pre, pos] = coordinates
+
+  useEffect(() => {
+    if (toolboxTooltip && toolboxTooltip.saveAsImageWithTitle) {
+      setTitle(false)
+    } else {
+      setTitle(true)
+    }
+  }, [toolboxTooltip])
+
+  const handleShowTitle = (show: boolean) => {
+    setTitle(show)
+  }
+
+  const myTool = toolboxTooltip && toolboxTooltip.saveAsImageWithTitle && {
+    myTool: getSaveAsImageWithTitle(
+      toolboxTooltip.saveAsImageWithTitle,
+      handleShowTitle
+    )
+  }
+
+  const saveAsImage = toolboxTooltip && toolboxTooltip.saveAsImage && {
+    saveAsImage: getSaveAsImage(toolboxTooltip.saveAsImage)
+  }
+
+  const toolbox = toolboxTooltip && {
+    ...TOOLBOX_DEFAULT_PROPS,
+    feature: {
+      ...myTool,
+      ...saveAsImage,
+      dataView: toolboxTooltip.dataView &&
+        getDataView(toolboxTooltip.dataView)
+    }
+  }
 
   const reference: TTuple[] = map(item => [item.x, item.y], ref)
   const preRespiratory: TTuple[] = map(item => [item.x, item.y], pre)
@@ -114,7 +154,7 @@ const CoordinateLineChart = (props: IProps) => {
     },
     title: {
       left: '6.2%',
-      show: titleProps !== undefined,
+      show: title,
       text: titleProps,
       textAlign: 'left',
       textStyle: {
@@ -126,13 +166,14 @@ const CoordinateLineChart = (props: IProps) => {
     grid: {
       containLabel: true,
       ...grid
-    }
+    },
+    toolbox
   }
 
   const widthStyle = { width: width || 'auto', height: height }
 
   return (
-    <ReactEcharts lazyUpdate style={widthStyle} option={options} />
+    <ReactEcharts style={widthStyle} option={options} />
   )
 }
 

--- a/src/core/DonutChart.tsx
+++ b/src/core/DonutChart.tsx
@@ -1,14 +1,16 @@
-import * as React from 'react'
+import React, { useEffect, useState } from 'react'
 import ReactEcharts from 'echarts-for-react'
 import { IProps } from './PieChart'
 import { TPieChartData, TPieDataLabel } from './types'
 import {
   getDataView,
   getSaveAsImage,
-  takeDonutComplement
+  takeDonutComplement,
+  getSaveAsImageWithTitle
 } from './auxiliarFunctions'
 import { map, sum } from 'ramda'
 import { formatToBRL } from 'brazilian-values'
+import { TOOLBOX_DEFAULT_PROPS } from './AreaChart'
 
 interface IDonutProps extends IProps {
   donutCenterValue?: string
@@ -35,6 +37,41 @@ export const DonutChart = (props: IDonutProps) => {
     centerPieValueFontSize,
     selectedMode
   } = props
+
+  const [title, setTitle] = useState(false)
+
+  useEffect(() => {
+    if (toolboxTooltip && toolboxTooltip.saveAsImageWithTitle) {
+      setTitle(false)
+    } else {
+      setTitle(true)
+    }
+  }, [toolboxTooltip])
+
+  const handleShowTitle = (show: boolean) => {
+    setTitle(show)
+  }
+
+  const myTool = toolboxTooltip && toolboxTooltip.saveAsImageWithTitle && {
+    myTool: getSaveAsImageWithTitle(
+      toolboxTooltip.saveAsImageWithTitle,
+      handleShowTitle
+    )
+  }
+
+  const saveAsImage = toolboxTooltip && toolboxTooltip.saveAsImage && {
+    saveAsImage: getSaveAsImage(toolboxTooltip.saveAsImage)
+  }
+
+  const toolbox = toolboxTooltip && {
+    ...TOOLBOX_DEFAULT_PROPS,
+    feature: {
+      ...myTool,
+      ...saveAsImage,
+      dataView: toolboxTooltip.dataView &&
+        getDataView(toolboxTooltip.dataView)
+    }
+  }
 
   const xData = map(item => item.name, props.data)
   const totalValues = sum(map(item => item.value, props.data))
@@ -65,24 +102,6 @@ export const DonutChart = (props: IDonutProps) => {
       ? formatToBRL(value)
       : takeDonutComplement(value, yComplement)
 
-  const toolbox = toolboxTooltip && {
-    showTitle: false,
-    right: '9.52%',
-    top: resultFormatType && '5.5%',
-    feature: {
-      saveAsImage:
-        toolboxTooltip.saveAsImage &&
-        getSaveAsImage(toolboxTooltip.saveAsImage),
-      dataView: toolboxTooltip.dataView && getDataView(toolboxTooltip.dataView)
-    },
-    tooltip: {
-      show: true,
-      backgroundColor: 'grey',
-      textStyle: {
-        fontSize: 12
-      }
-    }
-  }
 
   const options = {
     grid: props.grid,
@@ -90,7 +109,7 @@ export const DonutChart = (props: IDonutProps) => {
     title: {
       left: resultFormatType ? '0.1%' : '6.2%',
       top: resultFormatType && '5.7%',
-      show: titleProps !== undefined,
+      show: title,
       text: titleProps,
       textAlign: 'left',
       textStyle: {
@@ -162,7 +181,6 @@ export const DonutChart = (props: IDonutProps) => {
 
   return (
     <ReactEcharts
-      lazyUpdate
       style={WIDTH_STYLE}
       opts={widthOpts}
       option={options}

--- a/src/core/DonutChart.tsx
+++ b/src/core/DonutChart.tsx
@@ -6,7 +6,9 @@ import {
   getDataView,
   getSaveAsImage,
   takeDonutComplement,
-  getSaveAsImageWithTitle
+  getSaveAsImageWithTitle,
+  thousandSeparator,
+  getPercentage
 } from './auxiliarFunctions'
 import { map, sum } from 'ramda'
 import { formatToBRL } from 'brazilian-values'
@@ -77,7 +79,7 @@ export const DonutChart = (props: IDonutProps) => {
   const totalValues = sum(map(item => item.value, props.data))
 
   const formatTooltip = ({ name, value, marker }: TPieChartData) => {
-    const percent = value !== 0 ? (value * (100 / totalValues)).toFixed(2) : 0
+    const percent = getPercentage(value, totalValues)
     const valueWithPercent = resultFormatType === 'percent'
       ? value + ' (' + percent + '%)'
       : value
@@ -142,9 +144,7 @@ export const DonutChart = (props: IDonutProps) => {
         label: {
           color: 'black',
           position: 'center',
-          formatter:
-            donutCenterValue ||
-            totalValues.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.'),
+          formatter: donutCenterValue || thousandSeparator(totalValues),
           fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
           fontSize: centerPieValueFontSize || 24,
           fontWeight: '300' as const

--- a/src/core/ForecastAreaChart.tsx
+++ b/src/core/ForecastAreaChart.tsx
@@ -248,7 +248,6 @@ const ForecastAreaChart = (props: IProps) => {
         formatter: (item: string) =>
           xType === 'time' ? formatTime(item, 'dd MMM') : item,
         rotate: rotateLabel || 0,
-        interval: 0,
         fontSize: fontLabelSize || 11.5
       }
     },

--- a/src/core/HorizontalBarChart.tsx
+++ b/src/core/HorizontalBarChart.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState, useEffect } from 'react'
 import ReactEcharts from 'echarts-for-react'
 import {
   IDefaultChartProps,
@@ -14,10 +14,12 @@ import {
   getSaveAsImage,
   timeConvert,
   truncateLabel,
-  takeLabelComplement
+  takeLabelComplement,
+  getSaveAsImageWithTitle
 } from './auxiliarFunctions'
 import { reverse } from 'ramda'
 import { WIDTH_STYLE } from './DonutChart'
+import { TOOLBOX_DEFAULT_PROPS } from './AreaChart'
 
 interface IProps extends IDefaultChartProps {
   showTickInfos?: boolean
@@ -44,6 +46,20 @@ const HorizontalBarChart = (props: IProps) => {
     toolboxTooltip,
     marginRightToolbox
   } = props
+
+  const [title, setTitle] = useState(false)
+
+  useEffect(() => {
+    if (toolboxTooltip && toolboxTooltip.saveAsImageWithTitle) {
+      setTitle(false)
+    } else {
+      setTitle(true)
+    }
+  }, [toolboxTooltip])
+
+  const handleShowTitle = (show: boolean) => {
+    setTitle(show)
+  }
 
   const xData: TEntryWithStyleData[] = reverse(
     data.map((item: TEntryData) => {
@@ -104,24 +120,27 @@ const HorizontalBarChart = (props: IProps) => {
       : takeLabelComplement(Number(value), xComplement)
   }
 
-  const toolbox = toolboxTooltip && {
-    showTitle: false,
-    right: marginRightToolbox || '8.7%',
-    feature: {
-      saveAsImage:
-        toolboxTooltip.saveAsImage &&
-        getSaveAsImage(toolboxTooltip.saveAsImage),
-      dataView: toolboxTooltip.dataView && getDataView(toolboxTooltip.dataView)
-    },
-    tooltip: {
-      show: true,
-      backgroundColor: 'grey',
-      textStyle: {
-        fontSize: 12
-      }
-    }
+  const myTool = toolboxTooltip && toolboxTooltip.saveAsImageWithTitle && {
+    myTool: getSaveAsImageWithTitle(
+      toolboxTooltip.saveAsImageWithTitle,
+      handleShowTitle
+    )
   }
 
+  const saveAsImage = toolboxTooltip && toolboxTooltip.saveAsImage && {
+    saveAsImage: getSaveAsImage(toolboxTooltip.saveAsImage)
+  }
+
+  const toolbox = toolboxTooltip && {
+    ...TOOLBOX_DEFAULT_PROPS,
+    right: marginRightToolbox || '8.7%',
+    feature: {
+      ...myTool,
+      ...saveAsImage,
+      dataView: toolboxTooltip.dataView &&
+        getDataView(toolboxTooltip.dataView)
+    }
+  }
   const options = {
     grid: {
       containLabel: true,
@@ -215,7 +234,7 @@ const HorizontalBarChart = (props: IProps) => {
     },
     title: {
       left: marginLeftTitle || '5.9%',
-      show: titleProps !== undefined,
+      show: title,
       text: titleProps,
       textAlign: 'left',
       textStyle: {
@@ -243,7 +262,6 @@ const HorizontalBarChart = (props: IProps) => {
 
   return (
     <ReactEcharts
-      lazyUpdate
       style={WIDTH_STYLE}
       opts={widthOpts}
       onEvents={clickEvent}

--- a/src/core/LineChart.tsx
+++ b/src/core/LineChart.tsx
@@ -164,7 +164,6 @@ const LineChart = (props: IProps) => {
             )
             : item,
         rotate: rotateLabel || 0,
-        interval: 0,
         textStyle: {
           fontSize: fontLabelSize || 11.5
         }

--- a/src/core/PieChart.tsx
+++ b/src/core/PieChart.tsx
@@ -10,7 +10,8 @@ import {
   getDataView,
   getSaveAsImage,
   takeLabelComplement,
-  getSaveAsImageWithTitle
+  getSaveAsImageWithTitle,
+  getPercentage
 } from './auxiliarFunctions'
 import { formatToBRL } from 'brazilian-values'
 import { WIDTH_STYLE } from './DonutChart'
@@ -89,7 +90,7 @@ export const PieChart = (props: IProps) => {
 
   const formatTooltip = ({ name, value, marker }: TPieChartData) => {
     const title = tooltipTitle ? tooltipTitle + '<br>' : ''
-    const percent = value !== 0 ? (value * (100 / totalValues)).toFixed(2) : 0
+    const percent = getPercentage(value, totalValues)
     const valuePrint =
       resultFormatType === 'money' ? formatToBRL(value) : value
 

--- a/src/core/StackedBarChart.tsx
+++ b/src/core/StackedBarChart.tsx
@@ -317,7 +317,6 @@ const StackedBarChart = (props: IProps) => {
           formatter: (item: string) =>
             takeLabelComplement(Number(item), yComplement),
           fontSize: 11.5,
-          interval: 0
         },
         data: yBottomData as number[],
         splitLine: {

--- a/src/core/auxiliarFunctions.ts
+++ b/src/core/auxiliarFunctions.ts
@@ -7,6 +7,7 @@ import { TDataTooltip, TDomainValues } from './types'
 type TConnectedDataURL = {
   type?: string
   backgroundColor?: string
+  connectedBackgroundColor?: string
   excludeComponents?: string[]
 }
 
@@ -196,6 +197,7 @@ export const getSaveAsImageWithTitle = (
     const url = chartInfo.getConnectedDataURL({
       type: 'jpg',
       backgroundColor: '#fff',
+      connectedBackgroundColor: '#fff',
       excludeComponents: ['toolbox', 'dataZoom']
     })
 

--- a/src/core/auxiliarFunctions.ts
+++ b/src/core/auxiliarFunctions.ts
@@ -4,6 +4,22 @@ import { takeLast } from 'ramda'
 import ptBR from 'date-fns/locale/pt-BR'
 import { TDataTooltip, TDomainValues } from './types'
 
+type TConnectedDataURL = {
+  type?: string
+  backgroundColor?: string
+  excludeComponents?: string[]
+}
+
+const DOWNLOAD_ICON =
+  'path://M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 ' +
+  '.67l2.59-2.58L17 11.5l-5 5-5-5 1.41-1.41L11 12.67V3h2v9.67z'
+
+const iconStyle = {
+  color: '#152849',
+  borderColor: '#152849',
+  borderWidth: 0.1
+}
+
 export const takeLabelComplement = (item: number, complement: string) => {
   const getComplement = complement
     ? formatValueAxis(item, complement)
@@ -151,18 +167,53 @@ export const fixedDomain = (item: TDomainValues) =>
   item.max >= 90 ? 100 : getDomain(item)
 
 export const getSaveAsImage = (title: string) => ({
+  title,
   type: 'jpeg',
+  show: true,
+  icon: DOWNLOAD_ICON,
+  iconStyle,
+  excludeComponents: ['toolbox', 'dataZoom']
+})
+
+export const getSaveAsImageWithTitle = (
+  title: string,
+  setTitle: (show: boolean) => void
+) => ({
   title,
   show: true,
-  icon:
-    'path://M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 ' +
-    '.67l2.59-2.58L17 11.5l-5 5-5-5 1.41-1.41L11 12.67V3h2v9.67z',
-  iconStyle: {
-    color: '#152849',
-    borderColor: '#152849',
-    borderWidth: 0.1
-  },
-  excludeComponents: ['toolbox', 'dataZoom']
+  icon: DOWNLOAD_ICON,
+  iconStyle,
+  onclick: (
+    item: { option: { title: { text: string }[] } },
+    chartInfo: { getConnectedDataURL: (opts: TConnectedDataURL) => string }
+  ) => {
+    const title = item.option.title.length > 0
+      ? item.option.title[0].text
+      : 'image'
+
+    setTitle(true)
+
+    const url = chartInfo.getConnectedDataURL({
+      type: 'jpg',
+      backgroundColor: '#fff',
+      excludeComponents: ['toolbox', 'dataZoom']
+    })
+
+    const a = document.createElement('a')
+    a.download = title + '.jpeg'
+    a.target = '_blank'
+    a.href = url
+
+    const event = new MouseEvent('click', {
+      view: document.defaultView,
+      bubbles: true,
+      cancelable: false
+    })
+
+    a.dispatchEvent(event)
+
+    setTitle(false)
+  }
 })
 
 export const getDataView = (title: string) => ({

--- a/src/core/auxiliarFunctions.ts
+++ b/src/core/auxiliarFunctions.ts
@@ -59,12 +59,15 @@ export const takeComplement = (data: string | number, complement: string) =>
     ? ': ' + formatToBRL(data) + '<br>'
     : ': ' + data + complement + '<br>'
 
+export const getPercentage = (value: number, valueTotal: number) =>
+  value !== 0 ? (value * (100 / valueTotal)).toFixed(2) : '0'
+
 export const moneyPercent = (
   value: number,
   valueTotal: number,
   sumDataValues?: boolean
 ) => {
-  const percent = value !== 0 ? (value * (100 / valueTotal)).toFixed(2) : 0
+  const percent = getPercentage(value, valueTotal)
 
   return sumDataValues
     ? formatToBRL(value) + ' (' + percent + '%) <br>'
@@ -76,10 +79,9 @@ export const monuntTimeMessage = (
   stackedValues: number
 ) => {
   const time = timeConvert(Number(item.value))
-  const percent =
-    item.value !== 0
-      ? (Number(item.value) * (100 / stackedValues)).toFixed(2)
-      : 0
+  const percent = item.value !== 0 
+    ? getPercentage((Number(item.value)), stackedValues)
+    : '0'
 
   return item.seriesName + ': ' + time + ' (' + percent + '%) <br>'
 }
@@ -254,3 +256,9 @@ export const getInitialValues = (
 
 export const getEndForecast = (arrayLength: number, lineMarkValue: number) =>
   (lineMarkValue * 250) / arrayLength
+
+// This function take a number and put on this the thousand separator ".", e.g.:
+// 1000 => 1.000
+// 1000000 => 1.000.000 
+export const thousandSeparator = (values: string | number) =>
+  values.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,6 +28,7 @@ export interface IDefaultChartProps {
   marginRightToolbox?: string
   titleFontSize?: number
   scrollStart?: number
+  showTitleOnlySave?: boolean
   onClickBar?(
     itemProps?: Record<string, unknown>,
     itemFunctions?: Record<string, unknown>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,7 +28,6 @@ export interface IDefaultChartProps {
   marginRightToolbox?: string
   titleFontSize?: number
   scrollStart?: number
-  showTitleOnlySave?: boolean
   onClickBar?(
     itemProps?: Record<string, unknown>,
     itemFunctions?: Record<string, unknown>
@@ -38,6 +37,7 @@ export interface IDefaultChartProps {
 export type TToolboxEntryProps = {
   saveAsImage?: string
   dataView?: string
+  saveAsImageWithTitle?: string
 }
 
 export type TCoordinates = {

--- a/src/docz/AudiometryChart.mdx
+++ b/src/docz/AudiometryChart.mdx
@@ -12,8 +12,7 @@ import { Playground } from 'docz'
 <Playground>
     <div style={{ width: 600}}>
         <AudiometryChart
-            showTitleOnlySave
-            toolboxTooltip={{ saveAsImage: 'save as image' }}
+            toolboxTooltip={{ saveAsImageWithTitle: 'save as image' }}
             title='left'
             symbolsSize={ 16 }
             grid={ { left: "10%" } }

--- a/src/docz/AudiometryChart.mdx
+++ b/src/docz/AudiometryChart.mdx
@@ -12,6 +12,8 @@ import { Playground } from 'docz'
 <Playground>
     <div style={{ width: 600}}>
         <AudiometryChart
+            showTitleOnlySave
+            toolboxTooltip={{ saveAsImage: 'save as image' }}
             title='left'
             symbolsSize={ 16 }
             grid={ { left: "10%" } }

--- a/src/docz/CoordinateLineChart.mdx
+++ b/src/docz/CoordinateLineChart.mdx
@@ -15,47 +15,48 @@ import { Playground } from 'docz'
 <Playground>
     <CoordinateLineChart
         title='Respiratory volume chart'
-            height={400}
-            xMaxValue={8}
-            legendNames={['ref', 'pre', 'pos']}
-            coordinateNames={
-                {
-                    x: 'Volume (L)',
-                    y: 'Fluxo (L/s)'
-                }
+        toolboxTooltip={{ saveAsImageWithTitle: 'save as image' }}
+        height={400}
+        xMaxValue={8}
+        legendNames={['ref', 'pre', 'pos']}
+        coordinateNames={
+            {
+                x: 'Volume (L)',
+                y: 'Fluxo (L/s)'
             }
-            colors={['gray', 'orange', 'green']}
-            coordinates={ [ 
-                [
-                    { x: 0.1, y: 0.5 },
-                    { x: 0.4, y: 0.9 },
-                    { x: 2, y: 0.9 },
-                    { x: 3, y: 1 },
-                    { x: 4, y: 5.9 },
-                    { x: 5, y: 6 },
-                    { x: 6, y: 6 },
-                    { x: 8, y: 6 }
-                ],
-                [
-                    { x: 0.1, y: 7.5 },
-                    { x: 0.4, y: 7.3 },
-                    { x: 2, y: 7 },
-                    { x: 3, y: 6.5 },
-                    { x: 4, y: 2 },
-                    { x: 5, y: 4 },
-                    { x: 6, y: 4.3 },
-                    { x: 8, y: 7.5 },
-                ],
-                [
-                    { x: 0.1, y: 1 },
-                    { x: 0.4, y: 7.4 },
-                    { x: 2, y: 7.2 },
-                    { x: 3, y: 7.9 },
-                    { x: 4, y: 2.1 },
-                    { x: 5, y: 4.3 },
-                    { x: 6, y: 4.5 },
-                    { x: 8, y: 7.6 },
-                ]
+        }
+        colors={['gray', 'orange', 'green']}
+        coordinates={ [ 
+            [
+                { x: 0.1, y: 0.5 },
+                { x: 0.4, y: 0.9 },
+                { x: 2, y: 0.9 },
+                { x: 3, y: 1 },
+                { x: 4, y: 5.9 },
+                { x: 5, y: 6 },
+                { x: 6, y: 6 },
+                { x: 8, y: 6 }
+            ],
+            [
+                { x: 0.1, y: 7.5 },
+                { x: 0.4, y: 7.3 },
+                { x: 2, y: 7 },
+                { x: 3, y: 6.5 },
+                { x: 4, y: 2 },
+                { x: 5, y: 4 },
+                { x: 6, y: 4.3 },
+                { x: 8, y: 7.5 },
+            ],
+            [
+                { x: 0.1, y: 1 },
+                { x: 0.4, y: 7.4 },
+                { x: 2, y: 7.2 },
+                { x: 3, y: 7.9 },
+                { x: 4, y: 2.1 },
+                { x: 5, y: 4.3 },
+                { x: 6, y: 4.5 },
+                { x: 8, y: 7.6 },
+            ]
         ] }
     />
 </Playground>

--- a/src/docz/DonutChart.mdx
+++ b/src/docz/DonutChart.mdx
@@ -41,12 +41,12 @@ import { Playground } from 'docz'
         legendPosition='inside'
         labelFontColor='white'
         centerPieValueFontSize={ 28 }
-        resultFormatType="percent"
+        resultFormatType='percent'
         toolboxTooltip={{ saveAsImage: 'saving'}}
         title='Pesquisas relacionadas'
         center={ ['50%', '50%'] }
         donutRadius={ ['40%' , '70%'] }
-        donutCenterValue={ '83,35%' }
+        donutCenterValue='83,35%'
         data={ 
             [ 
                 { name: 'Com resposta', value: 781 },

--- a/src/docz/VerticalBarChart.mdx
+++ b/src/docz/VerticalBarChart.mdx
@@ -163,7 +163,7 @@ import { Playground } from 'docz'
 </Playground>
 
 
-# Vertical bar chart example
+# Vertical bar chart example with customMaxDomain
 <Playground>
     <VerticalBarChart
         showBarLabel
@@ -186,4 +186,25 @@ import { Playground } from 'docz'
           },
         ] }       
   />
+</Playground>
+
+# Vertical bar chart with dateFormat
+<Playground>
+      <VerticalBarChart
+          showBarLabel
+          title="Bar Chart example"
+          xType="time"
+          yComplement="%"
+          dateFormat="yyyy-MM"
+          color="blue"
+          customMaxDomain={100}
+          toolboxTooltip={{ saveAsImage: 'save as image' }}
+          tooltip={{ label: 'Date', result: 'Disp' }}
+          data={[
+              {
+                label: '2020-01',
+                result: '50',
+              }
+          ]}
+    />
 </Playground>


### PR DESCRIPTION
## Features:
- Allowed the `saveAsImageWithTitle` prop to download the chart with title in the following components:
   - `AudiometryChart`;
   - `CoordinateLineChart`;
   - `DonutChart`;
   - `HorizontalBarChart`;
   - `PieChart`.

## Fixes:
- Improve code style (move functions to auxiliar functions file);
- Add `thousandSeparator` function and his example;
- General fixes on examples.