### PR TITLE
0.4.1 - Allow legend below `AudiometryChart`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazing-react-charts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An amazing react charts package based in echarts",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/core/AudiometryChart.tsx
+++ b/src/core/AudiometryChart.tsx
@@ -24,7 +24,13 @@ interface IProps extends Omit<IDefaultChartProps, 'data'> {
   lineType?: TLineStyleType
   symbolsSize?: number
   colors?: string[]
+  legendsPosition?: 'top' | 'bottom'
+  legendGap?: number
+  legendType: 'scroll' | 'plain'
   legends?: TSimpleLegend[]
+  legendPadding?: number 
+  legendItemWidth?: number 
+  legendItemHeight?: number 
   tooltipMarker?: boolean
   formatTooltip?(items: TAudiometryDataTooltip[]): string
 }
@@ -45,6 +51,12 @@ const AudiometryChart = (props: IProps) => {
     colors,
     legends,
     tooltipMarker,
+    legendType,
+    legendsPosition,
+    legendGap,
+    legendPadding,
+    legendItemWidth,
+    legendItemHeight,
     formatTooltip
   } = props
 
@@ -73,6 +85,7 @@ const AudiometryChart = (props: IProps) => {
 
       return generateTooltip.join(' ')
     } else {
+      // TODO: remove this default tooltip to turn it generic
       const item = items.length > 0 ? items[0].data : { value: 0, boneValue: 0 }
 
       const result = item.value || item.value === 0
@@ -163,11 +176,22 @@ const AudiometryChart = (props: IProps) => {
     }
   }))
 
-  const legendProps = {
-    top: 30,
-    data: legends,
-    itemGap: 30
-  }
+  const legendProps =
+    legendsPosition === 'bottom'
+      ? {
+        data: legends,
+        top: 340,
+        type: legendType,
+        itemGap: legendGap || 5,
+        padding: legendPadding || 4,
+        itemWidth: legendItemWidth || 25,
+        itemHeight: legendItemHeight || 14
+      }
+      : {
+        top: 30,
+        data: legends,
+        itemGap: 30
+      }
 
   const dataWithNames = [...marksWithTypes, ...seriesData].map(
     (item, index) => ({

--- a/src/docz/AudiometryChart.mdx
+++ b/src/docz/AudiometryChart.mdx
@@ -104,13 +104,20 @@ import { Playground } from 'docz'
     <div style={{ width: 600}}>
         <AudiometryChart
             tooltipMarker
+            legendsPosition="bottom"
+            legendGap={7}
+            grid={{ bottom: 80 }}
             title='right'
             color='black'
             legends={[
                 { name: 'mark', icon: 'path://M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z' }, 
                 { name: 'red',  icon: 'path://M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z' }, 
-                { name: 'blue' }]}
-            colors={['red', 'red', 'blue']}
+                { name: 'blue' },
+                { name: 'item-special-second' },
+                { name: 'item-special-twelve' },
+                { name: 'item-special-bing-bang' }
+                ]}
+            colors={['red', 'red', 'blue', 'green', 'purple', 'yellow']}
             data={ [[
                 { 
                     result: 60,
@@ -149,30 +156,25 @@ import { Playground } from 'docz'
             ],
             [
                 { 
-                    result: 80
-                },
+                    result: 63
+                }           
+            ], 
+            [
                 {
-                    result: 60
-                },
-                {
-                    result: 60
-                },       
-                {
-                    result: 44
-                },
-                {
-                    result: 50
-                },
-                {
-                    result: 75
-                },
-                {
-                    result: 64
-                },
-                {
-                    result: 10
+                    result: 71
                 }
-            ]] }
+            ],
+                [
+                {
+                    result: 90
+                }
+            ],
+               [
+                {
+                    result: 51
+                }
+            ]
+            ]}
         />
     </div>
 </Playground>


### PR DESCRIPTION
## Changes:

- Added props to customize the legend (position, size, margin);
- Expanded example that wraps the new options in `AudiometryChart`. 

## Use:
- The prop `legendPosition` defines the legend's position (`top` or `bottom`) near chart; 
- The prop `legendType` defines the type of legend, if it's _scrollable_ or not;
- The prop `legendGap` is used to define the distance between the items inside legend box, e.g.:

```
legendPosition={ 10 }
```
This means that each item inside legendbox will have 10px distance to the other items (in all the directions).
