### PR TITLE
0.4.4 - Show 0 value on the auxResult array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazing-react-charts",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "An amazing react charts package based in echarts",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/core/StackedBarChart.tsx
+++ b/src/core/StackedBarChart.tsx
@@ -140,7 +140,7 @@ const StackedBarChart = (props: IProps) => {
     // This function is only used to show auxiliary values on tooltip.
     // We need to improve this component to allow users use it better.
     const getAuxToolTip = (dataIndex: number) =>
-      auxData?.length && auxData[dataIndex].result
+      auxData?.length && auxData[dataIndex].result >= 0
         ? generateAuxMessage(auxResult, auxData[dataIndex].result, yComplement)
         : ''
 

--- a/src/docz/StackedBarChart.mdx
+++ b/src/docz/StackedBarChart.mdx
@@ -158,7 +158,7 @@ import { Playground } from 'docz'
                     { label: '2019-06-01', result: 7 }
                 ],
                   [
-                    { label: '2019-01-01', result: 100 }, 
+                    { label: '2019-01-01', result: 0 }, 
                     { label: '2019-02-01', result: 76 },
                     { label: '2019-03-01', result: 558 }, 
                     { label: '2019-04-01', result: 10 },


### PR DESCRIPTION
## Fixes:

- Show the hint even the results are 0 on the `auxResult` array in `StackedBarChart` component.