### PR TITLE
0.4.5 - Move react and echarts dependencies to peerDependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "eslint": "7.1.0",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-react": "7.20.0",
-    "install-peers-cli": "^2.2.0",
+    "install-peers-cli": "2.2.0",
     "react-dom": "16.12.0",
     "typescript": "3.9.5"
   },
   "peerDependencies": {
-    "react": "17.0.1",
-    "echarts": "4.9.0"
+    "echarts": "4.9.0",
+    "react": "17.0.1"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5279,13 +5279,6 @@ echarts-for-react@2.0.16:
     fast-deep-equal "^2.0.1"
     size-sensor "^1.0.0"
 
-echarts@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-4.9.0.tgz#a9b9baa03f03a2a731e6340c55befb57a9e1347d"
-  integrity sha512-+ugizgtJ+KmsJyyDPxaw2Br5FqzuBnyOWwcxPKO6y0gc5caYcfnEUIlNStx02necw8jmKmTafmpHhGo4XDtEIA==
-  dependencies:
-    zrender "4.3.2"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -8064,7 +8057,7 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-install-peers-cli@^2.2.0:
+install-peers-cli@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/install-peers-cli/-/install-peers-cli-2.2.0.tgz#f76f1ec8ac9fa7f920c05743e011554edad85f8d"
   integrity sha512-scSNvF49HDOLNm2xLFwST23g/OvfsceiA087bcGBgZP/ZNCrvpSaCn5IrWNZ2XYmFFykXF/6J1Zgm+D/JgRgtA==
@@ -15141,11 +15134,6 @@ yurnalist@^2.1.0:
     is-ci "^2.0.0"
     read "^1.0.7"
     strip-ansi "^5.2.0"
-
-zrender@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-4.3.2.tgz#ec7432f9415c82c73584b6b7b8c47e1b016209c6"
-  integrity sha512-bIusJLS8c4DkIcdiK+s13HiQ/zjQQVgpNohtd8d94Y2DnJqgM1yjh/jpDb8DoL6hd7r8Awagw8e3qK/oLaWr3g==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
### Changes:
 - Moved from dependencies to peerDependencies, React and echarts libraries;
 - Added  install-peers-cli package to build package on the dev mode. 