### PR TITLE
fix(area-chart): add standard formatDate if undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazing-react-charts",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "An amazing react charts package based in echarts",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/lib/auxiliarFunctions.ts
+++ b/src/lib/auxiliarFunctions.ts
@@ -157,11 +157,10 @@ export const toDate = (text: string, format?: string) =>
 export const formatTime = (text: string, dateFormat = 'dd MMM') =>
   format(new Date(text), dateFormat, { locale: ptBR })
 
-export const formatTooltip = (text: string, dateFormat?: string) =>
-  format(
-    new Date(text), getDateFormatType(dateFormat, 'dd/MM/yyyy'), {
-      locale: ptBR
-    })
+export const formatTooltip = (text: string, dateFormat = 'dd MMM') => format(
+  new Date(text), getDateFormatType(dateFormat, 'dd/MM/yyyy'), {
+    locale: ptBR
+  })
 
 export const formatTooltipWithHours = (text: string) =>
   format(new Date(text), 'dd/MM/yyyy HH:mm', { locale: ptBR })


### PR DESCRIPTION
- Update function `formatTooltip` when formatDate not for the past.

[TASK HERE](https://dev.azure.com/nginformatica/Keepfy/_workitems/edit/24223)